### PR TITLE
Fix timeout using axios cancel token

### DIFF
--- a/lib/client.test.ts
+++ b/lib/client.test.ts
@@ -27,6 +27,12 @@ const mockCircuitBreaker = circuitBreaker as jest.Mocked<typeof circuitBreaker>;
 const mockValidStatus = validStatus as jest.Mocked<typeof validStatus>;
 const mockSettleResponse = settleResponse as jest.Mocked<typeof settleResponse>;
 
+//@ts-ignore
+mockAxios.CancelToken.source = jest.fn(()=>({
+    token: jest.fn(),
+    cancel: jest.fn()
+}));
+
 describe('client', () => {
     describe('constructor', () => {
         it('should add cache middleware if option set', async () => {
@@ -213,7 +219,9 @@ describe('client', () => {
                     },
                     id: 'test-uuid',
                     method: 'get',
-                    url: 'https://www.bbc.co.uk'
+                    url: 'https://www.bbc.co.uk',
+                    cancel: expect.any(Function),
+                    cancelToken: expect.any(Function)
                 }
             }
 

--- a/lib/middleware/timer.test.ts
+++ b/lib/middleware/timer.test.ts
@@ -2,7 +2,7 @@ import { timer } from './timer';
 
 const mockContext: MiddlewareContext = {
   client: { name: 'test', userAgent: 'melchett/test' },
-  request: { url: 'https://www.bbc.co.uk', method: 'get' }
+  request: { url: 'https://www.bbc.co.uk', method: 'get', cancel: jest.fn() }
 };
 
 describe('Timer middleware', () => {
@@ -12,7 +12,7 @@ describe('Timer middleware', () => {
 
     // Act
     try {
-      await timer()({ ...mockContext }, next);
+      await timer(1500)({ ...mockContext }, next);
     } catch (ex) {}
 
     // Assert
@@ -26,7 +26,7 @@ describe('Timer middleware', () => {
 
     // Act
     try {
-      await timer()(context, next);
+      await timer(1500)(context, next);
     } catch (ex) {}
 
     // Assert
@@ -41,7 +41,7 @@ describe('Timer middleware', () => {
 
     // Act
     try {
-      await timer()(context, next);
+      await timer(1500)(context, next);
     } catch (ex) {}
 
     // Assert
@@ -63,7 +63,7 @@ describe('Timer middleware', () => {
 
     // Act
     try {
-      await timer('x-response-time')(context, next);
+      await timer(1500, 'x-response-time')(context, next);
     } catch (ex) {}
 
     // Assert
@@ -76,11 +76,11 @@ describe('Timer middleware', () => {
 
     const errorResult = {
       name: 'ETIMEDOUT',
-      message: 'Timeout exceeded',
+      message: 'Timeout of 1ms exceeded',
     };
 
     // Assert
-    await expect(timer()({ ...mockContext, error: { code: 'ECONNABORTED' } }, next)).rejects.toMatchObject({
+    await expect(timer(1)({ ...mockContext, error: { message: 'ETIMEDOUT' } }, next)).rejects.toMatchObject({
       error: errorResult
     });
   });

--- a/lib/middleware/timer.ts
+++ b/lib/middleware/timer.ts
@@ -1,20 +1,26 @@
-const timer = (timingHeader?: string) => {
-  const getTimingFromHeader = (response) => {
-    if (timingHeader && response && response.headers) {
-      return parseFloat(response.headers[timingHeader]);
-    }
+const getTimingFromHeader = (timingHeader?: string, response?: any) => {
+  if (timingHeader && response && response.headers) {
+    return parseFloat(response.headers[timingHeader]);
   }
+}
 
+const timer = (timeout: number, timingHeader?: string) => {
   return async (ctx: MiddlewareContext, next) => {
     ctx.time = { start: Date.now() };
+
+    const timeoutHandle = setTimeout(() => {
+      ctx.request.cancel('ETIMEDOUT');
+    }, timeout);
  
     await next();
 
+    clearTimeout(timeoutHandle);
+
     ctx.time.end = Date.now();
-    ctx.time.elapsed = getTimingFromHeader(ctx.response) || ctx.time.end - ctx.time.start;
+    ctx.time.elapsed = getTimingFromHeader(timingHeader, ctx.response) || ctx.time.end - ctx.time.start;
  
-    if (ctx.error && ctx.error.code === 'ECONNABORTED') {
-      ctx.error = { name: 'ETIMEDOUT', message: 'Timeout exceeded' };
+    if (ctx.error && ctx.error.message === 'ETIMEDOUT') {
+      ctx.error = { name: 'ETIMEDOUT', message: `Timeout of ${timeout}ms exceeded` };
       return Promise.reject(ctx);
     }
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -28,7 +28,9 @@ interface RequestConfig {
   url: string,
   headers?: any,
   data?: any,
-  id?: string
+  id?: string,
+  cancel?: (arg0: string | object) => void,
+  cancelToken?: any
 }
 
 type MiddlewareContext = {

--- a/test/endtoend/melchett.test.ts
+++ b/test/endtoend/melchett.test.ts
@@ -7,6 +7,7 @@ const expectedRequest = {
     method: "get",
     url: "http://testurl.com/x"
 }
+
 const expectedResponse = {
     body: "",
     headers: {},
@@ -161,7 +162,7 @@ describe('melchett client', () => {
         beforeAll(async () => {
             nock('http://testurl.com')
                 .get('/x')
-                .delayConnection(2500)
+                .delayConnection(2000)
                 .reply(200, { data: 1 }, { 'x-response-time': '2000', 'content-length': '500' })
         });
     
@@ -169,7 +170,7 @@ describe('melchett client', () => {
             const client = new HttpClient({ name: 'test' });
             await expect(client.get('http://testurl.com/x'))
                 .rejects
-                .toMatchObject({ request: expectedRequest, response: {}, error: { name: `ETIMEDOUT`, message: 'Timeout exceeded' }});
+                .toMatchObject({ request: expectedRequest, response: {}, error: { name: `ETIMEDOUT`, message: 'Timeout of 1500ms exceeded' }});
         });
     });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Use the [axios cancellation API](https://github.com/axios/axios#cancellation) to abort requests that fail to yield a response within the specified timeout (regardless of whether the socket entered the connected state).

## Motivation and Context
Closes #21 

## How Has This Been Tested?
Update to existing unit tests and manual smoke test connecting to an endpoint that does not exist.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
