### PR TITLE
make the `next()` call from within the circuit breaker action

### DIFF
--- a/lib/middleware/circuitBreaker.ts
+++ b/lib/middleware/circuitBreaker.ts
@@ -1,21 +1,28 @@
 import CircuitBreaker from 'opossum';
 
-const tripPredicate = (status: number) => status < 500 ? Promise.resolve() : Promise.reject();
+const invalidStatusError = new Error('Status >= 500');
 
 const circuitBreakerHandler = (config: CircuitBreakerConfig) => {
   return async (ctx: MiddlewareContext, next) => {
     if (!ctx.client.state?.circuit) {
-      ctx.client.state.circuit = new CircuitBreaker(tripPredicate, config);
+      ctx.client.state.circuit = new CircuitBreaker((callback: () => Promise<unknown>) => callback(), config);
     }
 
-    if (ctx.client.state.circuit.opened === true) {
-      ctx.error = { name: 'ECIRCUITBREAKER', message: `Circuit breaker is open for ${ctx.client.name}` };
-      return Promise.reject(ctx);
+    try {
+      await ctx.client.state.circuit.fire(async () => {
+        await next();
+        if (ctx.response?.status >= 500) {
+          throw invalidStatusError;
+        }
+      });
+    } catch (e) {
+      if (CircuitBreaker.isOurError(e)) {
+        ctx.error = { name: 'ECIRCUITBREAKER', message: `Circuit breaker is open for ${ctx.client.name}` };
+        return Promise.reject(ctx);
+      } else if (e !== invalidStatusError) {
+        throw e;
+      }
     }
-
-    await next();
-
-    if (ctx.response) ctx.client.state.circuit.fire(ctx.response.status).catch(() => undefined);
   };
 };
 

--- a/lib/middleware/circuitBreaker.ts
+++ b/lib/middleware/circuitBreaker.ts
@@ -18,7 +18,7 @@ const circuitBreakerHandler = (config: CircuitBreakerConfig) => {
     } catch (e) {
       if (CircuitBreaker.isOurError(e)) {
         ctx.error = { name: 'ECIRCUITBREAKER', message: `Circuit breaker is open for ${ctx.client.name}` };
-        return Promise.reject(ctx);
+        throw ctx;
       } else if (e !== invalidStatusError) {
         throw e;
       }


### PR DESCRIPTION
## Description
Without this it's possible for the code run by `next` to throw, and this would not be considered in the circuit breaker calculations. This change also means that some opossum options like `options.capacity` will now function correctly.

## Motivation and Context
fixes #18

## How Has This Been Tested?
With the unit tests.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
