### PR TITLE
Expose Types

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -23,6 +23,7 @@ module.exports = {
       'no-new': ['off'],
       'prefer-promise-reject-errors': ['off'],
       '@typescript-eslint/explicit-function-return-type': 'off',
-      '@typescript-eslint/ban-ts-ignore':["off"]
+      '@typescript-eslint/ban-ts-ignore':["off"],
+      'no-useless-constructor': 'off'
     }
   };

--- a/lib/client.test.ts
+++ b/lib/client.test.ts
@@ -1,5 +1,5 @@
 import { HttpClient, request } from './client';
-import axios from 'axios';
+import axios, { AxiosInstance } from 'axios';
 import uuidv4 from 'uuid/v4';
 import compose from 'koa-compose';
 
@@ -187,7 +187,7 @@ describe('client', () => {
       const mockAgentRequest = jest.fn();
 
       const client = new HttpClient(clientConfig);
-      client._agent = { request: mockAgentRequest } as any;
+      client._agent = { request: mockAgentRequest } as unknown as AxiosInstance;
 
       // Act
       request(client, requestConfig);

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -12,7 +12,7 @@ import { settleResponse } from './utils/settleResponse';
 const version = require('./../package.json').version;
 const CancelToken = axios.CancelToken;
 
-const request = (client: HttpClient, config: RequestConfig) => {
+const request = (client: HttpClient, config: RequestConfig): Promise<SettledResponse | RejectedResponse> => {
   const requestId = uuidv4();
   config.headers = config.headers || {};
   config.headers['X-Correlation-Id'] = requestId;
@@ -95,15 +95,15 @@ class HttpClient {
     });
   }
 
-  get (url: string, headers?: object): Promise<any> {
+  get (url: string, headers?: HeaderObject) {
     return request(this, { method: 'get', url, headers });
   }
 
-  post (url: string, body: any, headers?: object): Promise<any> {
+  post (url: string, body: object, headers?: HeaderObject) {
     return request(this, { method: 'post', url, headers, data: body });
   }
 
-  delete (url: string, headers?: object): Promise<any> {
+  delete (url: string, headers?: HeaderObject) {
     return request(this, { method: 'delete', url, headers });
   }
 }

--- a/lib/middleware/caching.test.ts
+++ b/lib/middleware/caching.test.ts
@@ -136,11 +136,11 @@ describe('Caching middleware', () => {
       };
       const handler = caching(cache);
 
-      const mockContext: MiddlewareContext = {
+      const mockContext = {
         client: { name: 'test', userAgent: 'melchett/test' },
         request: { url: 'https://www.bbc.co.uk', method: 'get', headers: {} },
         response: { config: { method: 'get' }, headers: { 'cache-control': 'max-age=100' } }
-      };
+      } as unknown as MiddlewareContext;
       const nextFn = jest.fn();
 
       // Act & Assert
@@ -337,7 +337,7 @@ describe('Caching middleware', () => {
         client: { name: 'test', userAgent: 'melchett/test' },
         request: { url: 'https://www.bbc.co.uk', method: 'get', headers: {} },
         response: { config: { method: 'get' }, headers: { 'cache-control': 'max-age=100' } }
-      };
+      } as unknown as MiddlewareContext;
 
       // Act
       storeInCache(cache, context);
@@ -357,7 +357,7 @@ describe('Caching middleware', () => {
         client: { name: 'test', userAgent: 'melchett/test' },
         request: { url: 'https://www.bbc.co.uk', method: 'get', headers: {} },
         response: { config: { method: 'post' }, headers: { 'cache-control': 'max-age=100' } }
-      };
+      } as unknown as MiddlewareContext;
 
       // Act
       storeInCache(cache, context);

--- a/lib/middleware/circuitBreaker.test.ts
+++ b/lib/middleware/circuitBreaker.test.ts
@@ -3,7 +3,7 @@ import { circuitBreaker } from './circuitBreaker';
 const defaultContext: MiddlewareContext = {
   client: { name: 'client-name', userAgent: 'melchett/test', state: {} },
   request: { method: 'get', url: 'foo' },
-  response: { status: undefined }
+  response: { status: undefined } as MiddlewareContext['response']
 };
 
 let mockBreakerOpen;

--- a/lib/middleware/timer.test.ts
+++ b/lib/middleware/timer.test.ts
@@ -59,7 +59,7 @@ describe('Timer middleware', () => {
           'x-response-time': '23.4'
         }
       }
-    };
+    } as unknown as MiddlewareContext;
 
     // Act
     try {

--- a/lib/middleware/timer.ts
+++ b/lib/middleware/timer.ts
@@ -1,4 +1,4 @@
-const getTimingFromHeader = (timingHeader?: string, response?: any) => {
+const getTimingFromHeader = (timingHeader?: string, response?: MiddlewareContext['response']) => {
   if (timingHeader && response && response.headers) {
     return parseFloat(response.headers[timingHeader]);
   }

--- a/lib/middleware/validJson.test.ts
+++ b/lib/middleware/validJson.test.ts
@@ -38,7 +38,7 @@ describe('JSON validator middleware', () => {
     // Arrange
     const next = jest.fn();
 
-    const context = { ...mockContext, response: { data: 'failstring' } };
+    const context = { ...mockContext, response: { data: 'failstring' } } as unknown as MiddlewareContext;
 
     // Assert
     await expect(validJson(context, next)).rejects.toMatchObject({
@@ -50,7 +50,7 @@ describe('JSON validator middleware', () => {
     // Arrange
     const next = jest.fn();
 
-    const context = { ...mockContext, response: { data: { foo: 'bar' } } };
+    const context = { ...mockContext, response: { data: { foo: 'bar' } } } as unknown as MiddlewareContext;
 
     // Assert
     await expect(validJson(context, next)).resolves.toMatchObject(context);

--- a/lib/middleware/validStatus.test.ts
+++ b/lib/middleware/validStatus.test.ts
@@ -8,8 +8,7 @@ const mockContext: MiddlewareContext = {
 const errorResult = (status: number) => {
   return {
     name: `ESTATUS${status}`,
-    message: `Status code ${status} received for https://www.bbc.co.uk`,
-    details: ''
+    message: `Status code ${status} received for https://www.bbc.co.uk`
   };
 };
 

--- a/lib/middleware/validStatus.ts
+++ b/lib/middleware/validStatus.ts
@@ -5,8 +5,7 @@ const validStatus = (successPredicate: (status: number) => boolean) => {
     if (ctx.response && ctx.response.status && !successPredicate(ctx.response.status)) {
       ctx.error = {
         name: `ESTATUS${ctx.response.status}`,
-        message: `Status code ${ctx.response.status} received for ${ctx.request.url}`,
-        details: ctx.response.message || ''
+        message: `Status code ${ctx.response.status} received for ${ctx.request.url}`
       };
       return Promise.reject(ctx);
     }

--- a/lib/utils/settleResponse.test.ts
+++ b/lib/utils/settleResponse.test.ts
@@ -13,7 +13,8 @@ describe('Response settler', () => {
       response: {
         data: { foo: 'bar' },
         headers: { 'x-test': 'baz' },
-        status: 200
+        status: 200,
+        statusText: 'OK'
       }
     };
 

--- a/lib/utils/settleResponse.ts
+++ b/lib/utils/settleResponse.ts
@@ -1,10 +1,10 @@
-const settleResponse = (ctx: MiddlewareContext) => {
+const settleResponse = (ctx: MiddlewareContext): Promise<SettledResponse | RejectedResponse> => {
   const request = {
     client: ctx.client && ctx.client.name,
     url: ctx.request && ctx.request.url,
     id: ctx.request && ctx.request.id,
     headers: ctx.request && ctx.request.headers,
-    method: ctx.request && ctx.request.method,
+    method: (ctx.request && ctx.request.method) || undefined,
     body: ctx.request && ctx.request.data
   };
 
@@ -14,7 +14,7 @@ const settleResponse = (ctx: MiddlewareContext) => {
     status: ctx.response.status,
     duration: (ctx.time && ctx.time.elapsed !== undefined) ? ctx.time.elapsed : undefined,
     melchettCached: !!ctx.response.melchettCached
-  } : {};
+  } : undefined;
 
   if (!ctx.error && ctx.response) {
     return Promise.resolve({ request, response });

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
     "version": "3.1.0",
     "description": "A plugin-based HTTP client for NodeJS",
     "main": "dist/client.js",
+    "types": "lib/global.d.ts",
     "scripts": {
         "build": "rm -rf dist/ && npm run compile",
         "compile": "tsc",
@@ -20,7 +21,8 @@
         "url": "git+https://github.com/bbc/melchett.git"
     },
     "files": [
-        "dist/**/*"
+        "dist/**/*",
+        "**/*.d.ts"
     ],
     "author": "BBC",
     "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "types": "lib/global.d.ts",
     "scripts": {
         "build": "rm -rf dist/ && npm run compile",
-        "compile": "tsc",
+        "compile": "tsc --project tsconfig.build.json",
         "lint": "eslint lib test --ext .js,.ts,.tsx",
         "pretest": "npm run lint",
         "test": "jest",

--- a/test/endtoend/melchett.test.ts
+++ b/test/endtoend/melchett.test.ts
@@ -199,7 +199,7 @@ describe('melchett client', () => {
         setTimeout(async () => {
           resolve(expect(client.get('http://testurl.com/x'))
             .rejects
-            .toMatchObject({ request: expectedRequest, response: expectedResponse, error: { name: 'ESTATUS500', message: 'Status code 500 received for http://testurl.com/x', details: '' } }));
+            .toMatchObject({ request: expectedRequest, response: expectedResponse, error: { name: 'ESTATUS500', message: 'Status code 500 received for http://testurl.com/x' } }));
         }, 2000);
       });
     });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,7 +23,6 @@
         "lib/global.d.ts"
     ],
     "exclude": [
-        "./lib/**/*.test.ts",
         "node_modules",
         "dist"
     ]


### PR DESCRIPTION
## Description
Adding a bunch more types, especially on the values returned from requests (which are currently always `any`)

- Adding a module to the type declaration, and bundling it into the dist, so that consumers get types for the library
- Replaced a handful of `any` and `object`s with stricter types where possible
- Removed `ctx.error.details`, as TS revealed it was based on a value that doesn't exist, so was always an empty string. (This is the only change to any actual functionality)
- Turned TS on for the tests, as previously it was ignoring them entirely
- Added missing test coverage in the caching tests

## Motivation and Context
Types are nice!
The lack of bundled types currently means the `Promise<any>` types are getting lost and turned into `any`, so consumers can't even auto-complete `.then()`. Any promise chain from Melchett loses all its types every time you move into a new then/catch, no matter how far away from Melchett you get, even if all the code inside them is fully typed. That's not great 😞 

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
<!--- Include details of the tests you ran to see how your change -->
<!--- affects other areas of the code, etc. -->
Everything still builds, and copied into mountains to check it pulls the types through properly.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
